### PR TITLE
Add City Selection Screen

### DIFF
--- a/lib/dictionary_matcher.dart
+++ b/lib/dictionary_matcher.dart
@@ -39,6 +39,13 @@ const List<String> _foodWordList = [
   "tasting",
   "burger",
   "burgers",
+  // FR
+  "aliments",
+  "aliment",
+  "boisson",
+  "boissons",
+  "rafraîchissement",
+  "rafraîchissements",
 ];
 
 const _foodOccurances = ["🍔", "🍕", "🌭", "🌮"];

--- a/lib/dictionary_matcher.dart
+++ b/lib/dictionary_matcher.dart
@@ -1,4 +1,4 @@
-List<EventFilterMatch> getMatces(String test) => [
+List<EventFilterMatch> getMatches(String test) => [
       ..._applyMatcher(
         _drinkWordMatcher,
         EventFilterMatchType.Drink,
@@ -42,10 +42,10 @@ const List<String> _foodWordList = [
   // FR
   "aliments",
   "aliment",
-  "boisson",
-  "boissons",
-  "rafraîchissement",
-  "rafraîchissements",
+  // TR
+  "yemek",
+  "iftar",
+  "ikram",
 ];
 
 const _foodOccurances = ["🍔", "🍕", "🌭", "🌮"];
@@ -58,7 +58,16 @@ const List<String> _drinkWordList = [
   "wine",
   "wines",
   "refreshment",
-  "refreshments"
+  "refreshments",
+  // FR
+  "boisson",
+  "boissons",
+  "rafraîchissement",
+  "rafraîchissements",
+  // TR
+  "içecek",
+  "içki",
+  "bira",
 ];
 
 const _drinkOccurances = ["🍺", "🍻", "🍷", "🍾", "🍸", "☕️"];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,10 @@ class App extends StatelessWidget {
       providers: [
         ChangeNotifierProvider.value(value: MeetupPlatformSession()),
         ChangeNotifierProxyProvider<MeetupPlatformSession, Session>(
-          builder: (_, platform0, __) => Session(platforms: [platform0]),
+          builder: (_, platform0, prev) => Session(
+            platforms: [platform0],
+            location: prev != null ? prev.location : null,
+          ),
         ),
         ChangeNotifierProxyProvider<MeetupPlatformSession,
             MeetupPlatformEvents>(
@@ -49,17 +52,22 @@ class App extends StatelessWidget {
               print('App:Initializing');
               print('App:WaitingForNoReason');
               await Future.delayed(const Duration(seconds: 1));
-              print('App:RecoveringStoredSession');
+
+              print('App:RecoveringStoredSession:Platform0');
               await platform0.tryToConnectFromPrefs();
+
+              print('App:RecoveringStoredSession:Location');
+              await session.tryToLoadLocationFromPrefs();
+
               print('App:InitializationComplete');
             }(),
             builder: (_, snap) {
               if (snap.connectionState == ConnectionState.waiting) {
                 return SplashPage();
               } else {
-                return session.anyPlatformConnected
-                    ? EventsPage()
-                    : WelcomePage();
+                bool showWelcome = session.anyPlatformConnected == false ||
+                    session.location == null;
+                return showWelcome ? WelcomePage() : EventsPage();
               }
             },
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'package:event_dot_pizza/pages/city_selection_page.dart';
+import 'package:event_dot_pizza/pages/settings_page.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import './providers/meetup_platform_events.dart';
@@ -65,7 +67,9 @@ class App extends StatelessWidget {
             ConnectPlatformsPage.routeName: (_) => ConnectPlatformsPage(),
             MeetupAuthPage.routeName: (_) => MeetupAuthPage(),
             EventDetailPage.routeName: (_) => EventDetailPage(),
-            EventUrlPage.routeName: (_) => EventUrlPage()
+            EventUrlPage.routeName: (_) => EventUrlPage(),
+            CitySelectionPage.routeName: (_) => CitySelectionPage(),
+            SettingsPage.routeName: (_) => SettingsPage()
           },
         ),
       ),

--- a/lib/models/location.dart
+++ b/lib/models/location.dart
@@ -1,0 +1,22 @@
+class Location {
+  final String city, country;
+  final double lat, lon;
+
+  Location({this.city, this.country, this.lat, this.lon});
+
+  factory Location.fromJson(Map<String, dynamic> json) {
+    return Location(
+      city: json['city'],
+      country: json['localized_country_name'],
+      lat: json['lat'] as double,
+      lon: json['lon'] as double,
+    );
+  }
+
+  equalsTo(Location other) {
+    if (other == null) {
+      return false;
+    }
+    return lat == other.lat && lon == other.lon;
+  }
+}

--- a/lib/models/location.dart
+++ b/lib/models/location.dart
@@ -13,6 +13,13 @@ class Location {
     );
   }
 
+  Map<String, dynamic> toJson() => {
+        'city': city,
+        'localized_country_name': country,
+        'lat': lat,
+        'lon': lon,
+      };
+
   equalsTo(Location other) {
     if (other == null) {
       return false;

--- a/lib/models/settingItem.dart
+++ b/lib/models/settingItem.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/foundation.dart';
+
+class SettingItem {
+  String name, route, subtitle;
+  SettingItem({@required this.name, @required this.route, this.subtitle});
+}

--- a/lib/pages/city_selection_page.dart
+++ b/lib/pages/city_selection_page.dart
@@ -52,7 +52,7 @@ class _CitySelectionPageState extends State<CitySelectionPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text('Select City'),
+        title: Text('Select Your City'),
       ),
       body: SafeArea(
         child: Column(
@@ -61,7 +61,8 @@ class _CitySelectionPageState extends State<CitySelectionPage> {
             Padding(
               padding: EdgeInsets.all(10),
               child: TextField(
-                decoration: InputDecoration(hintText: 'Enter your city'),
+                decoration:
+                    InputDecoration(hintText: 'Type the name of your city'),
                 autofocus: true,
                 textCapitalization: TextCapitalization.words,
                 autocorrect: false,

--- a/lib/pages/city_selection_page.dart
+++ b/lib/pages/city_selection_page.dart
@@ -1,25 +1,105 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:provider/provider.dart';
+import '../platforms/meetup_platform_api.dart';
+import '../models/location.dart';
+import '../providers/session.dart';
 
-class CitySelectionPage extends StatelessWidget {
+class CitySelectionPage extends StatefulWidget {
   static const routeName = "citySelection";
 
   @override
+  _CitySelectionPageState createState() => _CitySelectionPageState();
+}
+
+class _CitySelectionPageState extends State<CitySelectionPage> {
+  void handleOnCityInputChanged(String text) {}
+  final cityInputOnChange = new BehaviorSubject<String>();
+  List<Location> locations = [];
+
+  void updateCityList(String query) async {
+    try {
+      List<Location> locs = await MeetupPlatformApi.findLocations(query);
+      this.setState(() => locations = locs);
+    } catch (e) {
+      throw "Failed to update city options";
+    }
+  }
+
+  @override
+  void initState() {
+    cityInputOnChange
+        .debounce((_) => TimerStream(true, const Duration(milliseconds: 650)))
+        .where((text) => text.trim().length > 1)
+        .listen(this.updateCityList);
+
+    super.initState();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    print('CitySelectionPage:Updated');
+    print('CitySelectionPage:Build');
+    final EdgeInsets safePadding = MediaQuery.of(context).padding;
+    Session session = Provider.of<Session>(context, listen: false);
+
+    // Put the selected city at the end of the list if it's not already in the list
+    final List<Location> renderLocs = [...locations];
+    if (session.location != null &&
+        renderLocs.indexWhere((loc) => loc.equalsTo(session.location)) == -1) {
+      renderLocs.add(session.location);
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: Text('Select City'),
       ),
       body: SafeArea(
-        child: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Text('lol city'),
-            ],
-          ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: <Widget>[
+            Padding(
+              padding: EdgeInsets.all(10),
+              child: TextField(
+                decoration: InputDecoration(hintText: 'Enter your city'),
+                autofocus: true,
+                textCapitalization: TextCapitalization.words,
+                autocorrect: false,
+                onChanged: (text) => cityInputOnChange.add(text),
+              ),
+            ),
+            // for (var loc in locations) Text("${loc.city}, ${loc.country}"),
+            Expanded(
+              child: ListView.separated(
+                padding: EdgeInsets.fromLTRB(0, 10.0, 0, safePadding.bottom),
+                itemCount: renderLocs.length,
+                separatorBuilder: (_, __) => const Divider(height: 1),
+                itemBuilder: (_, index) => CityListItem(
+                  location: renderLocs[index],
+                ),
+              ),
+            )
+          ],
         ),
       ),
+    );
+  }
+}
+
+class CityListItem extends StatelessWidget {
+  final Location location;
+  const CityListItem({Key key, @required this.location}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    Session session = Provider.of<Session>(context, listen: true);
+    bool selected = location.equalsTo(session.location);
+    return ListTile(
+      title: Text(location.city),
+      subtitle: Text(location.country),
+      onTap: () => session.location = location,
+      selected: selected,
+      trailing: selected ? Icon(Icons.pin_drop) : null,
     );
   }
 }

--- a/lib/pages/city_selection_page.dart
+++ b/lib/pages/city_selection_page.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class CitySelectionPage extends StatelessWidget {
+  static const routeName = "citySelection";
+
+  @override
+  Widget build(BuildContext context) {
+    print('CitySelectionPage:Updated');
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Select City'),
+      ),
+      body: SafeArea(
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Text('lol city'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/connect_platforms_page.dart
+++ b/lib/pages/connect_platforms_page.dart
@@ -33,7 +33,7 @@ class ConnectPlatformsPage extends StatelessWidget {
                     onPressed: () =>
                         Navigator.pushNamed(context, MeetupAuthPage.routeName),
                   ),
-                )
+                ),
               ],
             ),
           ),

--- a/lib/pages/events_page.dart
+++ b/lib/pages/events_page.dart
@@ -1,11 +1,14 @@
 import 'dart:async';
 
+import 'package:event_dot_pizza/models/location.dart';
 import 'package:event_dot_pizza/pages/settings_page.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../widgets/event_list.dart';
 import '../widgets/event_list_header.dart';
 import '../providers/meetup_platform_events.dart';
+import '../providers/session.dart';
+import '../models/location.dart';
 
 class EventsPage extends StatefulWidget {
   static const routeName = "events";
@@ -21,7 +24,11 @@ class _EventsPageState extends State<EventsPage> {
   }
 
   _refresh() {
-    Provider.of<MeetupPlatformEvents>(context).refresh();
+    Location location = Provider.of<Session>(context, listen: false).location;
+    Provider.of<MeetupPlatformEvents>(context).refresh(
+      lat: location.lat,
+      lon: location.lon,
+    );
   }
 
   @override

--- a/lib/pages/events_page.dart
+++ b/lib/pages/events_page.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
+import 'package:event_dot_pizza/pages/settings_page.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import './connect_platforms_page.dart';
 import '../widgets/event_list.dart';
 import '../widgets/event_list_header.dart';
 import '../providers/meetup_platform_events.dart';
@@ -34,7 +34,7 @@ class _EventsPageState extends State<EventsPage> {
           IconButton(
             icon: Icon(Icons.settings),
             onPressed: () =>
-                Navigator.pushNamed(context, ConnectPlatformsPage.routeName),
+                Navigator.pushNamed(context, SettingsPage.routeName),
           )
         ],
       ),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,0 +1,38 @@
+import 'package:event_dot_pizza/pages/city_selection_page.dart';
+import 'package:event_dot_pizza/pages/connect_platforms_page.dart';
+import 'package:flutter/material.dart';
+
+const Map<String, String> _settingRoutes = {
+  'Connect Platforms': ConnectPlatformsPage.routeName,
+  'Select City': CitySelectionPage.routeName
+};
+
+class SettingsPage extends StatelessWidget {
+  static const routeName = "settings";
+
+  @override
+  Widget build(BuildContext context) {
+    print('Settings:Updated');
+    final EdgeInsets safePadding = MediaQuery.of(context).padding;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Settings'),
+      ),
+      body: ListView.separated(
+        padding: EdgeInsets.fromLTRB(0, 10.0, 0, safePadding.bottom),
+        itemCount: _settingRoutes.keys.length,
+        separatorBuilder: (_, __) => const Divider(
+          height: 1,
+        ),
+        itemBuilder: (_, index) {
+          MapEntry _setting = _settingRoutes.entries.elementAt(index);
+          return ListTile(
+            title: Text(_setting.key),
+            trailing: Icon(Icons.keyboard_arrow_right),
+            onTap: () => Navigator.of(context).pushNamed(_setting.value),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,11 +1,9 @@
 import 'package:event_dot_pizza/pages/city_selection_page.dart';
 import 'package:event_dot_pizza/pages/connect_platforms_page.dart';
 import 'package:flutter/material.dart';
-
-const Map<String, String> _settingRoutes = {
-  'Connect Platforms': ConnectPlatformsPage.routeName,
-  'Select City': CitySelectionPage.routeName
-};
+import 'package:provider/provider.dart';
+import '../models/settingItem.dart';
+import '../providers/session.dart';
 
 class SettingsPage extends StatelessWidget {
   static const routeName = "settings";
@@ -13,6 +11,22 @@ class SettingsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     print('Settings:Updated');
+    Session session = Provider.of<Session>(context, listen: true);
+
+    final List<SettingItem> settings = [
+      SettingItem(
+        name: 'Connect Platforms',
+        route: ConnectPlatformsPage.routeName,
+      ),
+      SettingItem(
+        name: 'Select City',
+        route: CitySelectionPage.routeName,
+        subtitle: session.location != null
+            ? '${session.location.city}, ${session.location.country}'
+            : null,
+      ),
+    ];
+
     final EdgeInsets safePadding = MediaQuery.of(context).padding;
     return Scaffold(
       appBar: AppBar(
@@ -20,16 +34,15 @@ class SettingsPage extends StatelessWidget {
       ),
       body: ListView.separated(
         padding: EdgeInsets.fromLTRB(0, 10.0, 0, safePadding.bottom),
-        itemCount: _settingRoutes.keys.length,
-        separatorBuilder: (_, __) => const Divider(
-          height: 1,
-        ),
+        itemCount: settings.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
         itemBuilder: (_, index) {
-          MapEntry _setting = _settingRoutes.entries.elementAt(index);
+          SettingItem setting = settings[index];
           return ListTile(
-            title: Text(_setting.key),
+            title: Text(setting.name),
+            subtitle: setting.subtitle != null ? Text(setting.subtitle) : null,
             trailing: Icon(Icons.keyboard_arrow_right),
-            onTap: () => Navigator.of(context).pushNamed(_setting.value),
+            onTap: () => Navigator.of(context).pushNamed(setting.route),
           );
         },
       ),

--- a/lib/pages/welcome_page.dart
+++ b/lib/pages/welcome_page.dart
@@ -1,10 +1,57 @@
+import 'package:event_dot_pizza/pages/city_selection_page.dart';
 import 'package:flutter/material.dart';
 import './connect_platforms_page.dart';
+import '../providers/session.dart';
+import 'package:provider/provider.dart';
 
 class WelcomePage extends StatelessWidget {
   static const routeName = "welcome";
   @override
   Widget build(BuildContext context) {
+    Session session = Provider.of<Session>(context, listen: true);
+
+    Widget platforms = Visibility(
+      visible: !session.anyPlatformConnected,
+      child: Padding(
+        padding: EdgeInsets.all(20),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text(
+              'I rely on external event organization platforms to show nearby events to you. You need to log in to at least one of them to continue.',
+              textAlign: TextAlign.center,
+            ),
+            RaisedButton(
+              child: Text('Connect Platforms'),
+              onPressed: () =>
+                  Navigator.pushNamed(context, ConnectPlatformsPage.routeName),
+            )
+          ],
+        ),
+      ),
+    );
+
+    Widget location = Visibility(
+      visible: session.location == null,
+      child: Padding(
+        padding: EdgeInsets.all(20),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text(
+              'I need to know which city you are at, so I can show you the closest events.',
+              textAlign: TextAlign.center,
+            ),
+            RaisedButton(
+              child: Text('Select Your City'),
+              onPressed: () =>
+                  Navigator.pushNamed(context, CitySelectionPage.routeName),
+            )
+          ],
+        ),
+      ),
+    );
+
     return Scaffold(
         appBar: AppBar(
           title: Text('Event.Pizza'),
@@ -14,13 +61,18 @@ class WelcomePage extends StatelessWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
-                Text('Welcome!'),
-                Text('You need to connect them platforms.'),
-                RaisedButton(
-                  child: Text('Connect Platforms'),
-                  onPressed: () => Navigator.pushNamed(
-                      context, ConnectPlatformsPage.routeName),
-                )
+                Text(
+                  'Hi! 👋',
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 21),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: Text(
+                    'Before we begin, we need to set a coupe of things;',
+                  ),
+                ),
+                platforms,
+                location,
               ],
             ),
           ),

--- a/lib/platforms/meetup_platform_api.dart
+++ b/lib/platforms/meetup_platform_api.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../utils.dart';
 import '../providers/meetup_platform_event.dart';
+import '../models/location.dart';
 
 class MeetupPlatformApi {
   static const String kACCESS_TOKEN = 'access_token';
@@ -13,8 +14,9 @@ class MeetupPlatformApi {
       '&response_type=token' +
       '&redirect_uri=$REDIRECT_URI';
 
-  static const _upcomingEventsUri =
-      "https://api.meetup.com/find/upcoming_events";
+  static const _baseUri = "https://api.meetup.com";
+  static const _upcomingEventsUri = "$_baseUri/find/upcoming_events";
+  static const _findLocationsUri = "$_baseUri/find/locations";
 
   static Future<List<MeetupPlatformEvent>> fetchUpcomingEvents(
       String accessToken) async {
@@ -35,8 +37,6 @@ class MeetupPlatformApi {
 
     if (response.statusCode != 200) {
       // TODO: standardize error throwing
-      print(
-          'MeetupPlatformApi::fetchUpcomingEvents:StatusCode:${response.statusCode}');
       throw 'MeetupPlatformApi::fetchUpcomingEvents:StatusCode:${response.statusCode}';
     }
 
@@ -49,8 +49,31 @@ class MeetupPlatformApi {
     } catch (e) {
       // TODO: standardize error throwing
       print(e);
-      print(
-          'MeetupPlatformApi::fetchUpcomingEvents:FailedToDecodeJsonResponse');
+      throw 'MeetupPlatformApi::fetchUpcomingEvents:FailedToDecodeJsonResponse';
+    }
+  }
+
+  static Future<List<Location>> findLocations(String query) async {
+    http.Response response =
+        await http.get(_findLocationsUri + '?query=$query');
+
+    if (response.statusCode != 200) {
+      // TODO: standardize error throwing
+      throw 'MeetupPlatformApi::findLocations:StatusCode:${response.statusCode}';
+    }
+
+    try {
+      List<dynamic> decodedResponse = jsonDecode(response.body);
+      List<Location> locations =
+          decodedResponse.map((locData) => Location.fromJson(locData)).toList();
+      return locations;
+      // List<MeetupPlatformEvent> events = (decodedResponse['events'] as List)
+      //     .map((data) => MeetupPlatformEvent.fromJson(data))
+      //     .toList();
+      // return events;
+    } catch (e) {
+      // TODO: standardize error throwing
+      print(e);
       throw 'MeetupPlatformApi::fetchUpcomingEvents:FailedToDecodeJsonResponse';
     }
   }

--- a/lib/platforms/meetup_platform_api.dart
+++ b/lib/platforms/meetup_platform_api.dart
@@ -19,16 +19,16 @@ class MeetupPlatformApi {
   static const _findLocationsUri = "$_baseUri/find/locations";
 
   static Future<List<MeetupPlatformEvent>> fetchUpcomingEvents(
-      String accessToken) async {
+      double lat, double lon, String accessToken) async {
     if (isNullOrEmpty(accessToken)) {
       // TODO: standardize error throwing
       throw 'MeetupPlatformApi:FetchUpcomingEvents:NullOrEmptyAccessToken';
     }
-    const lat = '60.192059'; // TODO: use actual location instead
-    const lon = '24.945831';
+    print('?lat=$lat&lon=$lon');
     http.Response response = await http.get(
-        _upcomingEventsUri + '?lat=$lat&lon=$lon',
-        headers: {'Authorization': 'Bearer $accessToken'});
+      _upcomingEventsUri + '?lat=$lat&lon=$lon',
+      headers: {'Authorization': 'Bearer $accessToken'},
+    );
 
     if (response.statusCode == 401) {
       // TODO: standardize error throwing
@@ -67,10 +67,6 @@ class MeetupPlatformApi {
       List<Location> locations =
           decodedResponse.map((locData) => Location.fromJson(locData)).toList();
       return locations;
-      // List<MeetupPlatformEvent> events = (decodedResponse['events'] as List)
-      //     .map((data) => MeetupPlatformEvent.fromJson(data))
-      //     .toList();
-      // return events;
     } catch (e) {
       // TODO: standardize error throwing
       print(e);

--- a/lib/providers/event.dart
+++ b/lib/providers/event.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import '../platform_type.dart';
 
 class Event with ChangeNotifier {
+  // Does this need to be be ChangeNotifier, remove from providers if not
   String id;
   List<EventFilterMatch> matches = [];
   List<EventFilterMatchType> get matchTypes {

--- a/lib/providers/events.dart
+++ b/lib/providers/events.dart
@@ -17,7 +17,7 @@ class Events extends ChangeNotifier {
     platforms.forEach((platform) {
       _allEvents = [...platform.events, ...events];
       _allEvents.forEach((event) {
-        event.matches = matcher.getMatces(event.description);
+        event.matches = matcher.getMatches(event.description);
       });
       _events = _allEvents.where((event) => event.matches.length > 0).toList();
       _refreshing = _refreshing || platform.refreshing;

--- a/lib/providers/meetup_platform_events.dart
+++ b/lib/providers/meetup_platform_events.dart
@@ -23,11 +23,12 @@ class MeetupPlatformEvents with ChangeNotifier implements PlatformEvents {
   /// Calling this before app wasnt built yet will cause problems.
   /// Because it calls `notifyListeners()` right away.
   /// It is better if this is called inside `scheduleMicrotask()` callback.
-  Future<void> refresh() async {
+  Future<void> refresh({@required double lat, @required double lon}) async {
     _refreshing = true;
     notifyListeners();
     try {
-      _events = await MeetupPlatformApi.fetchUpcomingEvents(_accessToken);
+      _events =
+          await MeetupPlatformApi.fetchUpcomingEvents(lat, lon, _accessToken);
     } catch (e) {
       print('Provider:MeetupPlatformEvents:FailedToRefresh');
       print(e);

--- a/lib/providers/meetup_platform_session.dart
+++ b/lib/providers/meetup_platform_session.dart
@@ -27,18 +27,17 @@ class MeetupPlatformSession with ChangeNotifier implements PlatformSession {
     scheduleMicrotask(() => _saveToPrefs());
   }
 
-  Future<bool> tryToConnectFromPrefs() async {
+  Future<void> tryToConnectFromPrefs() async {
     print('tryToConnectFromPrefs');
     if (isConnected) {
-      return true;
+      return;
     }
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     if (!prefs.containsKey(kMeetupAccessToken)) {
-      return false;
+      return;
     }
     _accessToken = prefs.getString(kMeetupAccessToken);
     notifyListeners();
-    return isConnected;
   }
 
   Future<void> _saveToPrefs() async {

--- a/lib/providers/session.dart
+++ b/lib/providers/session.dart
@@ -1,12 +1,22 @@
-import 'package:flutter/material.dart';
-
+import 'package:flutter/foundation.dart';
+import '../models/location.dart';
 import './platform_session.dart';
 
 class Session extends ChangeNotifier {
   bool anyPlatformConnected;
-  Session({List<PlatformSession> platforms}) {
+
+  Location _location;
+  Location get location => _location;
+  set location(Location newLocation) {
+    _location = newLocation;
+    print('Provider:Session:location:Updated');
+    notifyListeners();
+  }
+
+  Session({List<PlatformSession> platforms, Location location}) {
     print('Provider:Session:Updated');
     anyPlatformConnected =
         platforms.where((platform) => platform.isConnected).length > 0;
+    location = _location;
   }
 }

--- a/lib/providers/session.dart
+++ b/lib/providers/session.dart
@@ -1,6 +1,12 @@
+import 'dart:async';
+import 'dart:convert';
 import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../models/location.dart';
+import '../utils.dart';
 import './platform_session.dart';
+
+const String kSelectedLocationJson = 'selectedLocationJson';
 
 class Session extends ChangeNotifier {
   bool anyPlatformConnected;
@@ -11,12 +17,48 @@ class Session extends ChangeNotifier {
     _location = newLocation;
     print('Provider:Session:location:Updated');
     notifyListeners();
+    scheduleMicrotask(() => _saveLocationToPrefs());
   }
 
-  Session({List<PlatformSession> platforms, Location location}) {
+  Session(
+      {@required List<PlatformSession> platforms,
+      @required Location location}) {
     print('Provider:Session:Updated');
     anyPlatformConnected =
         platforms.where((platform) => platform.isConnected).length > 0;
     location = _location;
+  }
+
+  Future<void> _saveLocationToPrefs() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (!isNullOrEmpty(_location)) {
+      try {
+        prefs.setString(kSelectedLocationJson, jsonEncode(_location.toJson()));
+      } catch (_) {
+        print('Failed to store location setting');
+      }
+    } else {
+      prefs.remove(kSelectedLocationJson);
+    }
+  }
+
+  Future<void> tryToLoadLocationFromPrefs() async {
+    print('tryToLoadLocationFromPrefs');
+    if (_location != null) {
+      return;
+    }
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (!prefs.containsKey(kSelectedLocationJson)) {
+      return;
+    }
+    try {
+      _location = Location.fromJson(jsonDecode(
+        prefs.getString(kSelectedLocationJson),
+      ));
+    } catch (_) {
+      print('Failed to load stored location setting');
+      _location = null;
+    }
+    notifyListeners();
   }
 }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -21,5 +21,5 @@ String getUserAgent() {
   if (Platform.isAndroid) {
     return 'Mozilla/5.0 (Linux; Android 7.0; SM-G930V Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36';
   }
-  throw 'User Agent Is Not Decided For This Platform';
+  throw 'User agent is not determined for the current platform';
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -116,6 +116,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.3"
+  rxdart:
+    dependency: "direct main"
+    description:
+      name: rxdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.22.2"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   http: ^0.12.0+2
   html: ^0.14.0+2
   url_launcher: ^5.1.2
+  rxdart: ^0.22.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
~If user hasn't selected a city before;
Before the Events Screen show a city selection screen modally ( can't be exited without making a choice)~

~There should be a list of cities and their lat lng locations that we can hardcode into the app~

Create a screen with city name input field which should;

- [x] Geocode the typed city name (google geocoding api?)
- [x] Show matching geocode results
- [x] User should tap on a city name to proceed
- [x] Write the selection to userdefaults
- [x] screen should not be dismissable (by close button?) until a city is selected

Also, to get to this screen

- [x] Create a settings screen
- [x] Which should open by tapping the gear button on main screen
- [x] Add a button to open city selection
- [x] Show city selection screen auto. at boot if user hasn't selected a location

```
Type a city name to Select Your City
Input: [Hels..]

Helsinki
Berlin
Munich
Turku
...
```