### PR TITLE
#11 Add two tabs for all events and today events

### DIFF
--- a/lib/pages/events_page.dart
+++ b/lib/pages/events_page.dart
@@ -12,6 +12,17 @@ class EventsPage extends StatefulWidget {
   _EventsPageState createState() => _EventsPageState();
 }
 
+const List<BottomNavigationBarItem> bottomNavigationBarItems = [
+  BottomNavigationBarItem(
+    icon: Icon(Icons.watch_later),
+    title: Text('Anytime'),
+  ),
+  BottomNavigationBarItem(
+    icon: Icon(Icons.calendar_today),
+    title: Text('Today'),
+  ),
+];
+
 class _EventsPageState extends State<EventsPage> {
   final _refreshIndicatorKey = new GlobalKey<RefreshIndicatorState>();
   Location _lastLoadedLocation;
@@ -26,14 +37,15 @@ class _EventsPageState extends State<EventsPage> {
   void _triggerRefresh() => SchedulerBinding.instance
       .addPostFrameCallback((_) => _refreshIndicatorKey.currentState?.show());
 
+  Widget listSeperatorBuilder(_, __) => const Divider(height: 1);
+
   @override
   Widget build(BuildContext context) {
     print('EventsPage:Build');
     final EdgeInsets safePadding = MediaQuery.of(context).padding;
+    final listEdgeInsets = EdgeInsets.fromLTRB(0, 10.0, 0, safePadding.bottom);
     final eventsProvider = Provider.of<Events>(context);
-    final events = _selectedIndex == 0
-        ? eventsProvider.events
-        : eventsProvider.todayEvents;
+    final eventLists = [eventsProvider.events, eventsProvider.todayEvents];
 
     if (_lastLoadedLocation != null) {
       if (eventsProvider.location.equalsTo(_lastLoadedLocation) == false) {
@@ -48,8 +60,10 @@ class _EventsPageState extends State<EventsPage> {
         actions: <Widget>[
           IconButton(
             icon: Icon(Icons.settings),
-            onPressed: () =>
-                Navigator.pushNamed(context, SettingsPage.routeName),
+            onPressed: () => Navigator.pushNamed(
+              context,
+              SettingsPage.routeName,
+            ),
           )
         ],
       ),
@@ -59,27 +73,23 @@ class _EventsPageState extends State<EventsPage> {
           Location location = await eventsProvider.refresh();
           setState(() => _lastLoadedLocation = location);
         },
-        child: ListView.separated(
-          physics: const AlwaysScrollableScrollPhysics(),
-          padding: EdgeInsets.fromLTRB(0, 10.0, 0, safePadding.bottom),
-          itemCount: events.length,
-          separatorBuilder: (_, __) => const Divider(height: 1),
-          itemBuilder: (_, index) => EventListItem(
-            event: events[index],
-          ),
+        child: IndexedStack(
+          index: _selectedIndex,
+          sizing: StackFit.expand,
+          children: eventLists.map((list) {
+            return Scrollbar(
+              child: ListView.separated(
+                padding: listEdgeInsets,
+                itemCount: list.length,
+                separatorBuilder: listSeperatorBuilder,
+                itemBuilder: (_, index) => EventListItem(event: list[index]),
+              ),
+            );
+          }).toList(),
         ),
       ),
       bottomNavigationBar: BottomNavigationBar(
-        items: const <BottomNavigationBarItem>[
-          BottomNavigationBarItem(
-            icon: Icon(Icons.home),
-            title: Text('All'),
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.calendar_today),
-            title: Text('Today'),
-          ),
-        ],
+        items: bottomNavigationBarItems,
         currentIndex: _selectedIndex,
         selectedItemColor: Theme.of(context).accentColor,
         onTap: (index) => setState(() => _selectedIndex = index),

--- a/lib/pages/events_page.dart
+++ b/lib/pages/events_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter/cupertino.dart';
 import '../pages/settings_page.dart';
 import '../widgets/event_list_item.dart';
 import '../providers/events.dart';
@@ -26,12 +25,6 @@ class _EventsPageState extends State<EventsPage> {
 
   void _triggerRefresh() => SchedulerBinding.instance
       .addPostFrameCallback((_) => _refreshIndicatorKey.currentState?.show());
-
-  void _onItemTapped(int index) {
-    setState(() {
-      _selectedIndex = index;
-    });
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -59,7 +52,7 @@ class _EventsPageState extends State<EventsPage> {
       ],
       currentIndex: _selectedIndex,
       selectedItemColor: Colors.red[800],
-      onTap: _onItemTapped,
+      onTap: (index) => setState(() => _selectedIndex = index),
     );
 
     return Scaffold(
@@ -73,7 +66,7 @@ class _EventsPageState extends State<EventsPage> {
           )
         ],
       ),
-      body: new Consumer<Events>(
+      body: Consumer<Events>(
         builder: (context, eventsProvider, _) => RefreshIndicator(
           key: _refreshIndicatorKey,
           onRefresh: () async {

--- a/lib/pages/events_page.dart
+++ b/lib/pages/events_page.dart
@@ -69,21 +69,19 @@ class _EventsPageState extends State<EventsPage> {
           )
         ],
       ),
-      body: Consumer<Events>(
-        builder: (context, eventsProvider, _) => RefreshIndicator(
-          key: _refreshIndicatorKey,
-          onRefresh: () async {
-            Location location = await eventsProvider.refresh();
-            setState(() => _lastLoadedLocation = location);
-          },
-          child: ListView.separated(
-            physics: const AlwaysScrollableScrollPhysics(),
-            padding: EdgeInsets.fromLTRB(0, 10.0, 0, safePadding.bottom),
-            itemCount: events.length,
-            separatorBuilder: (_, __) => const Divider(height: 1),
-            itemBuilder: (_, index) => EventListItem(
-              event: events[index],
-            ),
+      body: RefreshIndicator(
+        key: _refreshIndicatorKey,
+        onRefresh: () async {
+          Location location = await eventsProvider.refresh();
+          setState(() => _lastLoadedLocation = location);
+        },
+        child: ListView.separated(
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: EdgeInsets.fromLTRB(0, 10.0, 0, safePadding.bottom),
+          itemCount: events.length,
+          separatorBuilder: (_, __) => const Divider(height: 1),
+          itemBuilder: (_, index) => EventListItem(
+            event: events[index],
           ),
         ),
       ),

--- a/lib/pages/events_page.dart
+++ b/lib/pages/events_page.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:intl/intl.dart' show DateFormat;
 import '../pages/settings_page.dart';
 import '../widgets/event_list_item.dart';
 import '../providers/events.dart';
 import '../models/location.dart';
+import '../models/event.dart';
 
 class EventsPage extends StatefulWidget {
   static const routeName = "events";
@@ -14,6 +16,7 @@ class EventsPage extends StatefulWidget {
 
 class _EventsPageState extends State<EventsPage> {
   final _refreshIndicatorKey = new GlobalKey<RefreshIndicatorState>();
+  static const DATE_FORMAT = 'EEE, MMM d';
   Location _lastLoadedLocation;
   int _selectedIndex = 0;
 
@@ -25,6 +28,18 @@ class _EventsPageState extends State<EventsPage> {
 
   void _triggerRefresh() => SchedulerBinding.instance
       .addPostFrameCallback((_) => _refreshIndicatorKey.currentState?.show());
+
+  List<Event> getEventsByTabIndex(index) {
+    final events = Provider.of<Events>(context).events;
+    if (index == 0) {
+      return events;
+    }
+
+    return [
+      ...events.where((event) => event.formattedLocalDateTime
+          .contains(DateFormat(DATE_FORMAT).format(DateTime.now())))
+    ];
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -76,11 +91,10 @@ class _EventsPageState extends State<EventsPage> {
           child: ListView.separated(
             physics: const AlwaysScrollableScrollPhysics(),
             padding: EdgeInsets.fromLTRB(0, 10.0, 0, safePadding.bottom),
-            itemCount:
-                eventsProvider.getEventsByTabIndex(_selectedIndex).length,
+            itemCount: getEventsByTabIndex(_selectedIndex).length,
             separatorBuilder: (_, __) => const Divider(height: 1),
             itemBuilder: (_, index) => EventListItem(
-              event: eventsProvider.getEventsByTabIndex(_selectedIndex)[index],
+              event: getEventsByTabIndex(_selectedIndex)[index],
             ),
           ),
         ),

--- a/lib/pages/events_page.dart
+++ b/lib/pages/events_page.dart
@@ -51,7 +51,7 @@ class _EventsPageState extends State<EventsPage> {
         ),
       ],
       currentIndex: _selectedIndex,
-      selectedItemColor: Colors.red[800],
+      selectedItemColor: Theme.of(context).accentColor,
       onTap: (index) => setState(() => _selectedIndex = index),
     );
 

--- a/lib/pages/events_page.dart
+++ b/lib/pages/events_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/cupertino.dart';
 import '../pages/settings_page.dart';
 import '../widgets/event_list_item.dart';
 import '../providers/events.dart';
@@ -15,6 +16,7 @@ class EventsPage extends StatefulWidget {
 class _EventsPageState extends State<EventsPage> {
   final _refreshIndicatorKey = new GlobalKey<RefreshIndicatorState>();
   Location _lastLoadedLocation;
+  int _selectedIndex = 0;
 
   @override
   void initState() {
@@ -24,6 +26,12 @@ class _EventsPageState extends State<EventsPage> {
 
   void _triggerRefresh() => SchedulerBinding.instance
       .addPostFrameCallback((_) => _refreshIndicatorKey.currentState?.show());
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -38,6 +46,22 @@ class _EventsPageState extends State<EventsPage> {
       }
     }
 
+    final BottomNavigationBar bottomNavigationBar = new BottomNavigationBar(
+      items: const <BottomNavigationBarItem>[
+        BottomNavigationBarItem(
+          icon: Icon(Icons.home),
+          title: Text('All'),
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.calendar_today),
+          title: Text('Today'),
+        ),
+      ],
+      currentIndex: _selectedIndex,
+      selectedItemColor: Colors.red[800],
+      onTap: _onItemTapped,
+    );
+
     return Scaffold(
       appBar: AppBar(
         title: Text('Event.Pizza 🍕'),
@@ -49,7 +73,7 @@ class _EventsPageState extends State<EventsPage> {
           )
         ],
       ),
-      body: Consumer<Events>(
+      body: new Consumer<Events>(
         builder: (context, eventsProvider, _) => RefreshIndicator(
           key: _refreshIndicatorKey,
           onRefresh: () async {
@@ -59,14 +83,16 @@ class _EventsPageState extends State<EventsPage> {
           child: ListView.separated(
             physics: const AlwaysScrollableScrollPhysics(),
             padding: EdgeInsets.fromLTRB(0, 10.0, 0, safePadding.bottom),
-            itemCount: eventsProvider.events.length,
+            itemCount:
+                eventsProvider.getEventsByTabIndex(_selectedIndex).length,
             separatorBuilder: (_, __) => const Divider(height: 1),
             itemBuilder: (_, index) => EventListItem(
-              event: eventsProvider.events[index],
+              event: eventsProvider.getEventsByTabIndex(_selectedIndex)[index],
             ),
           ),
         ),
       ),
+      bottomNavigationBar: bottomNavigationBar,
     );
   }
 }

--- a/lib/pages/events_page.dart
+++ b/lib/pages/events_page.dart
@@ -42,22 +42,6 @@ class _EventsPageState extends State<EventsPage> {
       }
     }
 
-    final BottomNavigationBar bottomNavigationBar = new BottomNavigationBar(
-      items: const <BottomNavigationBarItem>[
-        BottomNavigationBarItem(
-          icon: Icon(Icons.home),
-          title: Text('All'),
-        ),
-        BottomNavigationBarItem(
-          icon: Icon(Icons.calendar_today),
-          title: Text('Today'),
-        ),
-      ],
-      currentIndex: _selectedIndex,
-      selectedItemColor: Theme.of(context).accentColor,
-      onTap: (index) => setState(() => _selectedIndex = index),
-    );
-
     return Scaffold(
       appBar: AppBar(
         title: Text('Event.Pizza 🍕'),
@@ -85,7 +69,21 @@ class _EventsPageState extends State<EventsPage> {
           ),
         ),
       ),
-      bottomNavigationBar: bottomNavigationBar,
+      bottomNavigationBar: BottomNavigationBar(
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.home),
+            title: Text('All'),
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.calendar_today),
+            title: Text('Today'),
+          ),
+        ],
+        currentIndex: _selectedIndex,
+        selectedItemColor: Theme.of(context).accentColor,
+        onTap: (index) => setState(() => _selectedIndex = index),
+      ),
     );
   }
 }

--- a/lib/pages/events_page.dart
+++ b/lib/pages/events_page.dart
@@ -1,51 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:intl/intl.dart' show DateFormat;
 import '../pages/settings_page.dart';
 import '../widgets/event_list_item.dart';
 import '../providers/events.dart';
 import '../models/location.dart';
-import '../models/event.dart';
 
 class EventsPage extends StatefulWidget {
   static const routeName = "events";
   @override
   _EventsPageState createState() => _EventsPageState();
-}
-
-class EventListWidget extends StatelessWidget {
-  final int selectedIndex;
-  static const DATE_FORMAT = 'EEE, MMM d';
-  EventListWidget(this.selectedIndex);
-
-  List<Event> getEventsByTabIndex(context) {
-    final events = Provider.of<Events>(context).events;
-
-    if (this.selectedIndex == 1) {
-      return events;
-    }
-
-    return events
-        .where((event) => event.formattedLocalDateTime
-            .contains(DateFormat(DATE_FORMAT).format(DateTime.now())))
-        .toList();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final EdgeInsets safePadding = MediaQuery.of(context).padding;
-
-    return ListView.separated(
-      physics: const AlwaysScrollableScrollPhysics(),
-      padding: EdgeInsets.fromLTRB(0, 10.0, 0, safePadding.bottom),
-      itemCount: getEventsByTabIndex(context).length,
-      separatorBuilder: (_, __) => const Divider(height: 1),
-      itemBuilder: (_, index) => EventListItem(
-        event: getEventsByTabIndex(context)[index],
-      ),
-    );
-  }
 }
 
 class _EventsPageState extends State<EventsPage> {
@@ -62,12 +26,14 @@ class _EventsPageState extends State<EventsPage> {
   void _triggerRefresh() => SchedulerBinding.instance
       .addPostFrameCallback((_) => _refreshIndicatorKey.currentState?.show());
 
-  final List<Widget> _eventListViews = [EventListWidget(0), EventListWidget(1)];
-
   @override
   Widget build(BuildContext context) {
     print('EventsPage:Build');
+    final EdgeInsets safePadding = MediaQuery.of(context).padding;
     final eventsProvider = Provider.of<Events>(context);
+    final events = _selectedIndex == 0
+        ? eventsProvider.events
+        : eventsProvider.todayEvents;
 
     if (_lastLoadedLocation != null) {
       if (eventsProvider.location.equalsTo(_lastLoadedLocation) == false) {
@@ -110,7 +76,15 @@ class _EventsPageState extends State<EventsPage> {
             Location location = await eventsProvider.refresh();
             setState(() => _lastLoadedLocation = location);
           },
-          child: _eventListViews[_selectedIndex],
+          child: ListView.separated(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: EdgeInsets.fromLTRB(0, 10.0, 0, safePadding.bottom),
+            itemCount: events.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (_, index) => EventListItem(
+              event: events[index],
+            ),
+          ),
         ),
       ),
       bottomNavigationBar: bottomNavigationBar,

--- a/lib/providers/events.dart
+++ b/lib/providers/events.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart' show DateFormat;
 import '../providers/platform_session.dart';
 import '../dictionary_matcher.dart' as matcher;
 import '../models/location.dart';
@@ -8,6 +9,10 @@ class Events extends ChangeNotifier {
   List<Event> _allEvents = [];
   List<Event> _events = [];
   List<Event> get events => [..._events];
+  List<Event> get todayEvents => [
+        ..._events.where((event) => event.formattedLocalDateTime
+            .contains(DateFormat('EEE, MMM d').format(DateTime.now())))
+      ];
   List<Event> get allEvents => [..._allEvents];
 
   bool _refreshing = false;
@@ -52,5 +57,9 @@ class Events extends ChangeNotifier {
       print('Event not found: $id');
       return null;
     }
+  }
+
+  List<Event> getEventsByTabIndex(int index) {
+    return index == 0 ? this._events : this.todayEvents;
   }
 }

--- a/lib/providers/events.dart
+++ b/lib/providers/events.dart
@@ -9,10 +9,6 @@ class Events extends ChangeNotifier {
   List<Event> _allEvents = [];
   List<Event> _events = [];
   List<Event> get events => [..._events];
-  List<Event> get todayEvents => [
-        ..._events.where((event) => event.formattedLocalDateTime
-            .contains(DateFormat('EEE, MMM d').format(DateTime.now())))
-      ];
   List<Event> get allEvents => [..._allEvents];
 
   bool _refreshing = false;
@@ -57,9 +53,5 @@ class Events extends ChangeNotifier {
       print('Event not found: $id');
       return null;
     }
-  }
-
-  List<Event> getEventsByTabIndex(int index) {
-    return index == 0 ? this._events : this.todayEvents;
   }
 }

--- a/lib/providers/events.dart
+++ b/lib/providers/events.dart
@@ -6,10 +6,15 @@ import '../models/location.dart';
 import '../models/event.dart';
 
 class Events extends ChangeNotifier {
+  static const DATE_FORMAT = 'EEE, MMM d';
   List<Event> _allEvents = [];
   List<Event> _events = [];
   List<Event> get events => [..._events];
   List<Event> get allEvents => [..._allEvents];
+  List<Event> get todayEvents => [
+        ..._events.where((event) => event.formattedLocalDateTime
+            .contains(DateFormat(DATE_FORMAT).format(DateTime.now())))
+      ];
 
   bool _refreshing = false;
   bool get refreshing => _refreshing;


### PR DESCRIPTION
Closes #11 
- [x] Added two new tabs in the event list view. By default it shows all events, and when users click to the `Today` tab, it only shows event for current day.
- [ ] Unit test

![Simulator Screen Shot - iPhone X - 2019-11-19 at 03 21 00](https://user-images.githubusercontent.com/199614/69107912-a3961a80-0a7b-11ea-9b0c-5c86093aceba.png)
![Simulator Screen Shot - iPhone X - 2019-11-19 at 03 21 06](https://user-images.githubusercontent.com/199614/69107913-a3961a80-0a7b-11ea-8dd2-605fe168355d.png)
